### PR TITLE
add x-strict-request-url handler

### DIFF
--- a/services/proxy.cors.sh/src/app.ts
+++ b/services/proxy.cors.sh/src/app.ts
@@ -54,6 +54,21 @@ app.use(limiter.hourly);
 app.use(limiter.monthly);
 
 // -- execution order matters --
+// (0)
+app.use((req, res, next) => {
+  // support 'x-strict-request-url'
+  // refer issue: https://github.com/gridaco/cors.sh/issues/38
+  const x_strict_request_url = req.headers["x-strict-request-url"];
+  if (x_strict_request_url && typeof x_strict_request_url === "string") {
+    // need prefix with '/' (required by cors_proxy to parse)
+    req.url = "/" + x_strict_request_url;
+    next();
+    return;
+  }
+
+  next();
+});
+
 // (1)
 app.use((req, res, next) => {
   if (res.headersSent) {


### PR DESCRIPTION
Ref: https://github.com/gridaco/cors.sh/issues/38

We are adding new header x-strict-request-url
Which users can set the same request url, but preventing it from getting altered (url-encoded, trailing slash being removed)

You can use this the same way you did, but with extra header

```js
// example with tiktok api
fetch("https://proxy.cors.sh/https://open.tiktokapis.com/v2/user/info/?fields=open_id", {
     headers: {
         "x-cors-api-key": "<your-cors.sh-api-key>",
         "Authorization": "Bearer <your-tiktok-token>",
         // NEW (enter the same url)
         "x-strict-request-url": "https://open.tiktokapis.com/v2/user/info/?fields=open_id"
    }
})
```