### PR TITLE
Add in-app CORS playground + mock.cors.sh test API

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,7 @@
 name: deploy
 
-# Deploys cors.sh to Cloudflare: the web app (Next 16 via OpenNext) + the proxy worker.
+# Deploys cors.sh to Cloudflare: the web app (Next 16 via OpenNext) + the proxy worker + the
+# mock test API (mock.cors.sh, the /playground default target).
 #
 # Manual-trigger by default so it never fires before the account is configured. To enable
 # auto-deploy on merge to main, uncomment the `push:` block below.
@@ -59,6 +60,10 @@ jobs:
       - name: Deploy proxy worker
         run: pnpm exec wrangler deploy
         working-directory: workers/proxy
+
+      - name: Deploy mock worker (mock.cors.sh — the /playground default test API)
+        run: pnpm exec wrangler deploy
+        working-directory: workers/mock
 
       - name: Deploy web (OpenNext)
         run: pnpm --filter web cf:deploy

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Add `proxy.cors.sh` to your request. For example,
 fetch("https://proxy.cors.sh/https://example.com/");
 ```
 
-## [`cors.sh/playground`](https://cors.sh/playground), The testing environment (forked from hoppscotch)
+## [Playground](https://cors.sh/playground)
 
-- [cors.sh/playground](https://cors.sh/playground)
-- [gridaco/playground.cors.sh](https://github.com/gridaco/playground.cors.sh)
-- [hoppscotch/hoppscotch](https://github.com/hoppscotch/hoppscotch)
+A built-in, in-browser CORS tester: paste any URL and watch the **direct** request get blocked by CORS, then watch the **same request through `proxy.cors.sh`** succeed — status, headers, and body, side by side. No API key required.
+
+It defaults to [`mock.cors.sh`](https://mock.cors.sh/no-cors) — our own CORS-reject test API (`/no-cors`, `/wrong-origin`, `/needs-preflight`, `/allow-all`), handy whenever you need an endpoint that reliably _fails_ CORS.
 
 ## Projects using CORS.SH
 
@@ -52,7 +52,7 @@ See [`DEVELOPMENT.md`](./DEVELOPMENT.md) for the full local setup, [`SPEC.md`](.
    Using a cors proxy service to connect to your own server is not a best practice.
    We'll consistently optimize our service infra to keep the paid version affordable as possible.
 
-2. The original code behind cors proxy is by Rob wu's cors-anywhere and the playground is forked from hoppscotch. both licensed under MIT, and our project cors.sh is also licensed under MIT License.
+2. cors.sh draws its lineage from Rob W's [cors-anywhere](https://github.com/Rob--W/cors-anywhere) (the proxy) and previously shipped a [Hoppscotch](https://github.com/hoppscotch/hoppscotch) fork as its playground — both MIT. The current service is a ground-up rebuild on Cloudflare Workers with its own built-in playground, also MIT-licensed.
 
 ## TODOs
 

--- a/scripts/stack.sh
+++ b/scripts/stack.sh
@@ -55,6 +55,8 @@ AUTH_URL=http://localhost:3000
 EMAIL_DRY_RUN=1
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 INTERNAL_SECRET=local_internal
+# The /playground page points its requests at the local proxy (prod default: proxy.cors.sh).
+PLAYGROUND_PROXY_URL=http://localhost:8786
 VARS
   # Stripe: dummy by default (webhook-signature tests sign their own events). Override via env
   # with a real Stripe TEST key + test price ids to exercise the live checkout/portal calls
@@ -79,6 +81,7 @@ VARS
 
   echo "[4/5] wait for readiness"
   wait_url http://127.0.0.1:3000/api/v1/usage
+  wait_url http://127.0.0.1:3000/playground
   wait_url http://127.0.0.1:8788/allow-all
   wait_url http://127.0.0.1:8090/
   curl -s -o /dev/null --retry 90 --retry-delay 1 --retry-connrefused http://127.0.0.1:8786/ && echo "  up: proxy 8786"

--- a/tests/e2e/playground.spec.ts
+++ b/tests/e2e/playground.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "@playwright/test";
+
+// The playground page is served by the web app (3000), not the page-origin baseURL (8090).
+const WEB = process.env.WEB_URL || "http://localhost:3000";
+const MOCK = process.env.MOCK_URL || "http://localhost:8788"; // mock-reject API (workers/mock)
+
+test("playground: direct request is blocked, the same request via the proxy succeeds", async ({
+  page,
+}) => {
+  await page.goto(`${WEB}/playground`);
+
+  // Target a deliberately no-CORS endpoint that is cross-origin to the web app → the browser
+  // blocks the direct fetch, and the proxy (PLAYGROUND_PROXY_URL → local proxy) rewrites it.
+  await page.getByLabel("Target URL").fill(`${MOCK}/no-cors`);
+  await page.getByRole("button", { name: "Run" }).click();
+
+  // Direct panel: blocked by the browser.
+  await expect(page.getByText("Blocked by the browser")).toBeVisible();
+
+  // Proxy panel: a 200 means JS could read the response — impossible for a CORS-blocked request.
+  await expect(page.getByText(/200 OK/)).toBeVisible();
+
+  // The proxied response carries the cors.sh-injected header (only the proxy panel has tabs).
+  await page.getByRole("tab", { name: /headers/i }).click();
+  await expect(page.getByText("access-control-allow-origin").first()).toBeVisible();
+});

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -16,6 +16,8 @@ export default defineConfig({
     { name: "billing", testMatch: /billing\.spec\.ts/ },
     // Opt-in: real Stripe test-mode checkout (skips unless RUN_STRIPE_LIVE + a real key).
     { name: "billing-live", testMatch: /billing-live\.spec\.ts/ },
+    // The /playground page drives the browser's own fetch() (navigates to the web app, not baseURL).
+    { name: "playground", testMatch: /playground\.spec\.ts/ },
     // Dashboard suite runs with a real session.
     {
       name: "authed",

--- a/web/app/(home)/playground/page.tsx
+++ b/web/app/(home)/playground/page.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from "next";
+import { Playground } from "@/components/playground";
+import { bindings } from "@/lib/control/bindings";
+
+// Reads a runtime binding (proxy base) → must render per request, not at build time.
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Playground",
+  description:
+    "Fire a request from your browser, watch it get blocked by CORS, then watch the same request succeed through the cors.sh proxy. No API key required.",
+};
+
+export default function PlaygroundPage() {
+  // Defaults to the production proxy; e2e overrides it to the local proxy via PLAYGROUND_PROXY_URL.
+  const proxyBase = bindings().PLAYGROUND_PROXY_URL ?? "https://proxy.cors.sh";
+
+  return (
+    <div className="mx-auto max-w-5xl px-6 py-16 sm:py-20">
+      <div className="mx-auto max-w-2xl text-center">
+        <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">Playground</h1>
+        <p className="mt-4 text-base text-muted-foreground sm:text-lg">
+          Fire a request straight from your browser and watch it get blocked by CORS — then watch
+          the same request sail through{" "}
+          <code className="font-mono text-foreground">proxy.cors.sh</code>. No key required.
+        </p>
+      </div>
+      <Playground proxyBase={proxyBase} />
+    </div>
+  );
+}

--- a/web/cloudflare-env.d.ts
+++ b/web/cloudflare-env.d.ts
@@ -20,6 +20,9 @@ declare global {
     NEXT_PUBLIC_APP_URL?: string;
     // Shared secret the proxy presents when pinging the quota-notification endpoint.
     INTERNAL_SECRET?: string;
+    // Proxy base for the /playground page. Defaults to https://proxy.cors.sh; e2e points it
+    // at the local proxy so the playground test is self-contained.
+    PLAYGROUND_PROXY_URL?: string;
   }
 }
 

--- a/web/components/playground.tsx
+++ b/web/components/playground.tsx
@@ -1,0 +1,411 @@
+"use client";
+
+import * as React from "react";
+import { toast } from "sonner";
+import { Loader2Icon } from "lucide-react";
+import { Button } from "@workspace/ui/components/button";
+import { Input } from "@workspace/ui/components/input";
+import { Textarea } from "@workspace/ui/components/textarea";
+import { Label } from "@workspace/ui/components/label";
+import { Badge } from "@workspace/ui/components/badge";
+import { Alert, AlertDescription, AlertTitle } from "@workspace/ui/components/alert";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@workspace/ui/components/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@workspace/ui/components/select";
+import { cn } from "@workspace/ui/lib/utils";
+import { CodeBlock } from "@/components/code-block";
+import { humanizeBytes } from "@/lib/format";
+
+const METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
+type Method = (typeof METHODS)[number];
+
+// Default to our own mock (mock.cors.sh) — purpose-built to reject CORS, so the *direct* request
+// reliably fails and the proxied one returns clean JSON. `/wrong-origin` is also blocked (its ACAO
+// points elsewhere); the real-API chip is CORS-open, so its direct request succeeds — itself useful
+// to see (not every endpoint needs the proxy).
+const EXAMPLES = [
+  "https://mock.cors.sh/no-cors",
+  "https://mock.cors.sh/wrong-origin",
+  "https://api.github.com/repos/gridaco/cors.sh",
+];
+
+const MAX_BODY = 100 * 1024; // cap what we render; bodies can be huge
+
+type RunResult =
+  | {
+      ok: true;
+      status: number;
+      statusText: string;
+      ms: number;
+      headers: [string, string][];
+      body: string;
+      truncated: boolean;
+      fullSize: number;
+    }
+  | { ok: false; ms: number; errorName: string; errorMessage: string };
+
+/** "Header: value" per line → object. Blank and `#` lines are ignored. */
+function parseHeaders(text: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of text.split("\n")) {
+    const t = line.trim();
+    if (!t || t.startsWith("#")) continue;
+    const i = t.indexOf(":");
+    if (i === -1) continue;
+    const k = t.slice(0, i).trim();
+    if (k) out[k] = t.slice(i + 1).trim();
+  }
+  return out;
+}
+
+async function timedFetch(url: string, init: RequestInit): Promise<RunResult> {
+  const start = performance.now();
+  try {
+    const r = await fetch(url, init);
+    const ms = Math.round(performance.now() - start);
+    const raw = await r.text();
+    const fullSize = raw.length;
+    let body = raw;
+    // Pretty-print JSON when parseable; otherwise show as-is.
+    try {
+      body = JSON.stringify(JSON.parse(raw), null, 2);
+    } catch {
+      // not JSON — leave raw text
+    }
+    const truncated = body.length > MAX_BODY;
+    return {
+      ok: true,
+      status: r.status,
+      statusText: r.statusText,
+      ms,
+      headers: [...r.headers.entries()],
+      body: truncated ? body.slice(0, MAX_BODY) : body,
+      truncated,
+      fullSize,
+    };
+  } catch (e) {
+    const err = e as Error;
+    return {
+      ok: false,
+      ms: Math.round(performance.now() - start),
+      errorName: err.name || "Error",
+      errorMessage: String(err.message || err),
+    };
+  }
+}
+
+export function Playground({ proxyBase }: { proxyBase: string }) {
+  const [url, setUrl] = React.useState(EXAMPLES[0]!);
+  const [method, setMethod] = React.useState<Method>("GET");
+  const [apiKey, setApiKey] = React.useState("");
+  const [headersText, setHeadersText] = React.useState("");
+  const [body, setBody] = React.useState("");
+  const [showAdvanced, setShowAdvanced] = React.useState(false);
+  const [pending, setPending] = React.useState(false);
+  const [direct, setDirect] = React.useState<RunResult | null>(null);
+  const [proxied, setProxied] = React.useState<RunResult | null>(null);
+
+  const hasBody = method !== "GET";
+  const base = proxyBase.replace(/\/$/, "");
+  const proxiedUrl = `${base}/${url}`;
+
+  async function run() {
+    if (!/^https?:\/\//i.test(url)) {
+      toast.error("Enter an absolute http(s) URL");
+      return;
+    }
+    setPending(true);
+    setDirect(null);
+    setProxied(null);
+
+    const headers = parseHeaders(headersText);
+    const init: RequestInit = {
+      method,
+      headers,
+      body: hasBody && body ? body : undefined,
+    };
+    const [d, p] = await Promise.all([
+      timedFetch(url, init), // direct: no key, the browser enforces CORS
+      timedFetch(proxiedUrl, {
+        ...init,
+        headers: { ...headers, ...(apiKey ? { "x-cors-api-key": apiKey } : {}) },
+      }),
+    ]);
+    setDirect(d);
+    setProxied(p);
+    setPending(false);
+  }
+
+  function snippet(): string {
+    const out = [
+      `await fetch(${JSON.stringify(proxiedUrl)}, {`,
+      `  method: ${JSON.stringify(method)},`,
+      "  headers: {",
+    ];
+    for (const [k, v] of Object.entries(parseHeaders(headersText))) {
+      out.push(`    ${JSON.stringify(k)}: ${JSON.stringify(v)},`);
+    }
+    out.push(
+      apiKey
+        ? `    "x-cors-api-key": ${JSON.stringify(apiKey)},`
+        : `    // "x-cors-api-key": "live_…",  // optional — anonymous works too`,
+    );
+    out.push("  },");
+    if (hasBody && body) out.push(`  body: ${JSON.stringify(body)},`);
+    out.push("});");
+    return out.join("\n");
+  }
+
+  return (
+    <div className="mt-10 space-y-6">
+      {/* Request bar */}
+      <div className="rounded-2xl border bg-background p-4 sm:p-6">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <Select value={method} onValueChange={(v) => setMethod(v as Method)}>
+            <SelectTrigger className="h-9 w-full sm:w-28" aria-label="HTTP method">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {METHODS.map((m) => (
+                <SelectItem key={m} value={m}>
+                  {m}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Input
+            aria-label="Target URL"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") run();
+            }}
+            placeholder="https://api.example.com/data"
+            className="h-9 flex-1 font-mono"
+            spellCheck={false}
+          />
+          <Button onClick={run} disabled={pending} className="h-9 sm:w-28">
+            {pending ? <Loader2Icon className="animate-spin" /> : null}
+            {pending ? "Running" : "Run"}
+          </Button>
+        </div>
+
+        <div className="mt-3 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+          <span className="mr-1">Try:</span>
+          {EXAMPLES.map((ex) => (
+            <button
+              key={ex}
+              type="button"
+              onClick={() => setUrl(ex)}
+              className="rounded-full border bg-muted/40 px-2 py-0.5 font-mono transition-colors hover:bg-muted hover:text-foreground"
+            >
+              {ex.replace(/^https?:\/\//, "")}
+            </button>
+          ))}
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setShowAdvanced((s) => !s)}
+          className="mt-4 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+        >
+          {showAdvanced ? "− Hide" : "+ Show"} advanced — API key, headers{hasBody ? ", body" : ""}
+        </button>
+
+        {showAdvanced && (
+          <div className="mt-4 grid gap-4 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="pg-key" className="text-xs">
+                API key <span className="text-muted-foreground">(optional)</span>
+              </Label>
+              <Input
+                id="pg-key"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder="live_… / test_… — blank = anonymous"
+                className="h-9 font-mono"
+                spellCheck={false}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="pg-headers" className="text-xs">
+                Request headers <span className="text-muted-foreground">(one per line)</span>
+              </Label>
+              <Textarea
+                id="pg-headers"
+                value={headersText}
+                onChange={(e) => setHeadersText(e.target.value)}
+                placeholder={"Authorization: Bearer …\nAccept: application/json"}
+                className="resize-y font-mono text-xs"
+                rows={3}
+              />
+            </div>
+            {hasBody && (
+              <div className="space-y-1.5 sm:col-span-2">
+                <Label htmlFor="pg-body" className="text-xs">
+                  Request body
+                </Label>
+                <Textarea
+                  id="pg-body"
+                  value={body}
+                  onChange={(e) => setBody(e.target.value)}
+                  placeholder={'{ "hello": "world" }'}
+                  className="resize-y font-mono text-xs"
+                  rows={4}
+                />
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Results: direct (blocked) vs via proxy (success) */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <ResultPanel
+          label="Direct browser request"
+          subtitle="no proxy"
+          kind="direct"
+          result={direct}
+          pending={pending}
+        />
+        <ResultPanel
+          label="Via proxy.cors.sh"
+          subtitle={base}
+          kind="proxy"
+          result={proxied}
+          pending={pending}
+        />
+      </div>
+      <p className="text-center text-xs text-muted-foreground">
+        Both requests run in your browser&apos;s own <code className="font-mono">fetch()</code>, so
+        CORS is genuinely enforced — this isn&apos;t a server-side simulation.
+      </p>
+
+      {/* Copy-as-fetch */}
+      <div>
+        <h2 className="mb-2 text-sm font-medium">Copy this request</h2>
+        <CodeBlock code={snippet()} filename="proxied-request.js" />
+      </div>
+    </div>
+  );
+}
+
+function ResultPanel({
+  label,
+  subtitle,
+  kind,
+  result,
+  pending,
+}: {
+  label: string;
+  subtitle: string;
+  kind: "direct" | "proxy";
+  result: RunResult | null;
+  pending: boolean;
+}) {
+  return (
+    <div className="flex min-w-0 flex-col rounded-2xl border bg-background">
+      <div className="flex items-center justify-between gap-2 border-b px-4 py-3">
+        <div className="min-w-0">
+          <div className="text-sm font-medium">{label}</div>
+          <div className="truncate font-mono text-[11px] text-muted-foreground">{subtitle}</div>
+        </div>
+        {result &&
+          (result.ok ? (
+            <Badge
+              variant="outline"
+              className="border-emerald-500/30 text-emerald-600 dark:text-emerald-400"
+            >
+              {result.status}
+              {result.statusText ? ` ${result.statusText}` : ""} · {result.ms} ms
+            </Badge>
+          ) : (
+            <Badge variant="destructive">Blocked · {result.ms} ms</Badge>
+          ))}
+      </div>
+
+      <div className="p-4">
+        {pending && !result && <p className="text-xs text-muted-foreground">Running…</p>}
+        {!pending && !result && (
+          <p className="text-xs text-muted-foreground">Run a request to see the result.</p>
+        )}
+
+        {result && !result.ok && (
+          <Alert variant="destructive">
+            <AlertTitle>
+              {kind === "direct" ? "Blocked by the browser" : "Request failed"}
+            </AlertTitle>
+            <AlertDescription className="space-y-2">
+              {kind === "direct" ? (
+                <p>
+                  The browser refused to expose this response — almost certainly a CORS error.
+                  JavaScript can&apos;t read the exact reason; open{" "}
+                  <strong>DevTools → Network</strong> to see it. This is exactly what cors.sh fixes
+                  — compare the panel on the right.
+                </p>
+              ) : null}
+              <p className="font-mono text-[11px] text-destructive">
+                {result.errorName}: {result.errorMessage}
+              </p>
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {result && result.ok && (
+          <Tabs defaultValue="body" className="min-w-0 flex-col">
+            <TabsList>
+              <TabsTrigger value="body">Body</TabsTrigger>
+              <TabsTrigger value="headers">Headers ({result.headers.length})</TabsTrigger>
+            </TabsList>
+            <TabsContent value="body" className="mt-3 min-w-0">
+              <CodeBlock code={result.body || "(empty body)"} copy={result.body.length > 0} />
+              {result.truncated && (
+                <p className="mt-1.5 text-[11px] text-muted-foreground">
+                  Showing the first {humanizeBytes(MAX_BODY)} of {humanizeBytes(result.fullSize)}.
+                </p>
+              )}
+            </TabsContent>
+            <TabsContent value="headers" className="mt-3 min-w-0">
+              <dl className="divide-y overflow-hidden rounded-xl border text-xs">
+                {result.headers.map(([k, v]) => {
+                  const cors = k.toLowerCase().startsWith("access-control-");
+                  return (
+                    <div
+                      key={k}
+                      className={cn(
+                        "grid grid-cols-[minmax(0,13.5rem)_1fr] gap-2 px-3 py-1.5",
+                        cors && "bg-emerald-500/5",
+                      )}
+                    >
+                      <dt
+                        className={cn(
+                          "truncate font-mono",
+                          cors ? "text-emerald-600 dark:text-emerald-400" : "text-muted-foreground",
+                        )}
+                      >
+                        {k}
+                      </dt>
+                      <dd className="font-mono break-all">{v}</dd>
+                    </div>
+                  );
+                })}
+              </dl>
+              {kind === "proxy" && (
+                <p className="mt-1.5 text-[11px] text-muted-foreground">
+                  <span className="text-emerald-600 dark:text-emerald-400">access-control-*</span>{" "}
+                  headers are injected by cors.sh — that&apos;s why the browser allowed this
+                  response.
+                </p>
+              )}
+            </TabsContent>
+          </Tabs>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -10,18 +10,6 @@ const nextConfig = {
   transpilePackages: ["@workspace/ui", "@workspace/emails"],
   // Let .md / .mdx files under app/ become routes (docs live in-app, no separate project).
   pageExtensions: ["ts", "tsx", "md", "mdx"],
-  rewrites() {
-    return [
-      {
-        source: "/playground",
-        destination: "https://playground.cors.sh",
-      },
-      {
-        source: "/playground/:path*",
-        destination: "https://playground.cors.sh/:path*",
-      },
-    ];
-  },
   redirects() {
     return [
       // Note: legacy keyless proxy traffic to `cors.sh/<url>` is handled by a Cloudflare route

--- a/workers/mock/wrangler.jsonc
+++ b/workers/mock/wrangler.jsonc
@@ -3,4 +3,7 @@
   "main": "src/index.ts",
   "compatibility_date": "2025-01-01",
   "workers_dev": true,
+  // Public CORS-reject test API used as the /playground default target. Must be a DIFFERENT
+  // origin than cors.sh so the browser actually enforces CORS on a direct request.
+  "routes": [{ "pattern": "mock.cors.sh", "custom_domain": true }],
 }


### PR DESCRIPTION
## Summary

Replaces the `cors.sh/playground` page — which rewrote to a **4-year-old Hoppscotch fork** (`gridaco/playground.cors.sh`) on Vercel and **503'd** when that project idle-paused — with a small, custom **in-app CORS tester**, plus a public test API (`mock.cors.sh`) we control.

After researching off-the-shelf options (embeddable API consoles, HTTP clients, CORS testers), none fit: they either need an OpenAPI spec or proxy _around_ CORS — the opposite of what we need to demonstrate. So this is a hand-rolled component (the de-facto standard in this space — every CORS-proxy project ships its own small fetch form).

## What's in it

**`/playground`** (`web/app/(home)/playground` + `web/components/playground.tsx`)

- Paste a URL → **Run** → fires the _same_ request **directly** and **via `proxy.cors.sh`** side by side, in the browser's own `fetch()` so CORS is genuinely enforced.
- Direct → blocked, with honest copy (JS can't read the CORS reason; points to DevTools — it never fakes a "CORS" label). Proxied → `200` with the response **body** (pretty-printed JSON) and **headers** (the cors.sh-injected `access-control-*` highlighted as the proof).
- Method, optional `x-cors-api-key`, request headers, and body (advanced disclosure); copy-as-`fetch()` snippet. Works **keyless** (anonymous tier).

**`mock.cors.sh`** — deployed `workers/mock` to a custom domain as the default target. A purpose-built CORS-reject API (`/no-cors`, `/wrong-origin`, `/needs-preflight`, `/allow-all`) on a _different origin_ than `cors.sh`, so the "blocked" demo is reliable (no dependence on a third party's CORS config) and returns clean JSON. Added to `deploy.yml`.

**Wiring**

- Removed the `/playground → playground.cors.sh` rewrite in `next.config.mjs`.
- Proxy base read from a runtime binding `PLAYGROUND_PROXY_URL` (default `proxy.cors.sh`); `stack.sh` overrides it to the local proxy so the e2e is self-contained.
- New `tests/e2e/playground.spec.ts` (+ playwright project): a real browser asserts direct-blocked + proxied-`200` + the injected `access-control-allow-origin`.

## Verification

- `pnpm format` / `lint` / `check-types` ✅, `pnpm build` ✅ (`/playground` is a dynamic route)
- `pnpm test:e2e` ✅ **21/21** (the new spec + no regressions)
- Driven live in a browser (dark + light, desktop + mobile) — fixed horizontal overflow, tab layout, and the status badge during polish
- `mock.cors.sh` verified live: direct → `200` with no ACAO (browser blocks); via proxy → `200` + `access-control-allow-origin: *`

## Notes for reviewers

- `mock.cors.sh` is **already deployed** (custom domain on the cors.sh zone, like `proxy.cors.sh`). The `/playground` default takes effect when `web` next deploys.
- The mock worker is named `cors-mock-dev` to match the existing `cors-proxy-dev` / `cors-web-dev`; a `-dev`→prod rename is a separate cleanup.
- README's Playground section + disclaimer updated (it still called the playground a Hoppscotch fork).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-browser CORS playground that lets you compare a direct browser request with a proxied request side by side.
  * The playground now supports method selection, custom headers, request bodies, and a copyable request snippet.
  * A new public test endpoint is available for trying blocked requests and verifying proxy behavior.

* **Bug Fixes**
  * Updated local and hosted playground routing so the page loads consistently and uses the intended proxy target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->