### PR TITLE
ci: auto-deploy to Cloudflare on merge to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,8 @@ name: deploy
 # Deploys cors.sh to Cloudflare: the web app (Next 16 via OpenNext) + the proxy worker + the
 # mock test API (mock.cors.sh, the /playground default target).
 #
-# Manual-trigger by default so it never fires before the account is configured. To enable
-# auto-deploy on merge to main, uncomment the `push:` block below.
+# Auto-deploys on merge to main; also runnable manually via workflow_dispatch (with a
+# migrate toggle). Auto-deploys always apply D1 migrations (forward-only, idempotent).
 #
 # Required GitHub repo secrets:
 #   CLOUDFLARE_API_TOKEN   — token with Workers Scripts:Edit, D1:Edit, KV:Edit, Workers Routes:Edit
@@ -20,8 +20,8 @@ on:
         description: "Apply remote D1 migrations before deploying"
         type: boolean
         default: true
-  # push:
-  #   branches: [main]
+  push:
+    branches: [main]
 
 concurrency:
   group: deploy-production
@@ -52,8 +52,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # Idempotent: applies only not-yet-applied migrations. Forward-only.
+      # Runs on push (auto-deploy) always; on manual dispatch only when the migrate toggle is on.
       - name: Apply D1 migrations (remote)
-        if: ${{ inputs.migrate }}
+        if: ${{ github.event_name == 'push' || inputs.migrate }}
         run: pnpm exec wrangler d1 migrations apply DB --remote
         working-directory: web
 


### PR DESCRIPTION
## What

Enable automatic production deploys. Merging to `main` now runs the existing [deploy.yml](.github/workflows/deploy.yml) (migrate → proxy → mock → web) — the closest thing to a Vercel-style flow on Cloudflare. The manual `workflow_dispatch` button stays.

## Why

The playground (#172) is merged to `main` but never reached production: `deploy.yml` was manual-trigger-only **and** had never run (repo secrets weren't set). Secrets are now configured (`CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`, verified for D1 + Workers access). This PR flips on the auto-trigger so the merge ships everything currently on `main`.

## Bug fix included

The D1 migrate step was gated on `if: ${{ inputs.migrate }}`, which is empty on `push` events → auto-deploys would **silently skip migrations**. Now: `if: ${{ github.event_name == 'push' || inputs.migrate }}`.

## Security (open-source repo)

- Deploy creds are encrypted GitHub secrets, referenced via `${{ secrets.* }}` — never hardcoded.
- `deploy.yml` triggers only on push-to-main / manual dispatch (fork PRs can't reach it); `ci.yml` uses no secrets, so fork PRs can't exfiltrate.
- No `.dev.vars`/`.env` tracked; gitignore confirmed.

Merging this triggers the first real production deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployments now automatically run when changes are pushed to the main branch.
  * Manual deployment is still available for on-demand releases.
* **Chores**
  * Database migrations are now applied automatically during supported deployment runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->