### PR TITLE
ci: build OpenNext bundle before deploying web

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,5 +66,10 @@ jobs:
         run: pnpm exec wrangler deploy
         working-directory: workers/mock
 
+      # opennextjs-cloudflare deploy ships pre-built output only; build the OpenNext
+      # bundle (runs next build internally) before deploying.
+      - name: Build web (OpenNext)
+        run: pnpm --filter web cf:build
+
       - name: Deploy web (OpenNext)
         run: pnpm --filter web cf:deploy


### PR DESCRIPTION
Follow-up to #173. The first auto-deploy succeeded through D1 migrate + proxy + mock, then failed at **Deploy web (OpenNext)**:

```
ERROR Could not find compiled Open Next config, did you run the build command?
```

`cf:deploy` (`opennextjs-cloudflare deploy`) only ships pre-built output; the workflow never ran `cf:build`. This adds a **Build web (OpenNext)** step before the deploy. Merging re-triggers the auto-deploy to verify end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the web deployment process to include an additional build step before publishing, helping ensure deployments are prepared correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->